### PR TITLE
Fix vesselfmu hanging

### DIFF
--- a/src/proxyfmu/process_helper.hpp
+++ b/src/proxyfmu/process_helper.hpp
@@ -61,7 +61,7 @@ void start_process(
 
     bool bound = false;
     std::string line;
-    while (pipe_stream && std::getline(pipe_stream, line) && !line.empty()) {
+    while (pipe_stream && std::getline(pipe_stream, line)) {
         if (!bound && line.substr(0, 16) == "[proxyfmu] port=") {
             {
                 std::lock_guard<std::mutex> lck(mtx);
@@ -70,8 +70,10 @@ void start_process(
             }
             cv.notify_one();
             bound = true;
-        } else if (line.substr(0, 10) == "[proxyfmu]") {
-            std::cout << line << std::endl;
+        } else if (line.substr(0, 16) == "[proxyfmu] freed") {
+            break;
+        } else {
+            std::cerr << line << std::endl;
         }
     }
 

--- a/src/proxyfmu/server/fmu_service_handler.cpp
+++ b/src/proxyfmu/server/fmu_service_handler.cpp
@@ -119,4 +119,5 @@ void fmu_service_handler::freeInstance()
     std::cout << "[proxyfmu] Shutting down proxy for '" << modelName_ << "::" << instanceName_ << "'";
     stop_();
     std::cout << " done.." << std::endl;
+    std::cout << "[proxyfmu] freed";
 }


### PR DESCRIPTION
This PR fixes an issue where some FMUs (VesselFmu.fmu) would hang. The issue was use of empty print statements in the target model. This PR should resolve that, hopefully without introducing new issues.

Also, enabling print statements from the model. These are written to `std::cerr` (just to give them another color).
