### PR TITLE
Callback member initialisation.

### DIFF
--- a/src/proxyfmu/fmi/fmi1/fmi1_slave.cpp
+++ b/src/proxyfmu/fmi/fmi1/fmi1_slave.cpp
@@ -34,6 +34,7 @@ fmi1_slave::fmi1_slave(
     callbackFunctions.allocateMemory = std::calloc;
     callbackFunctions.freeMemory = std::free;
     callbackFunctions.logger = fmilogger;
+    callbackFunctions.stepFinished = nullptr;
 
     if (fmi1_import_create_dllfmu(handle_, callbackFunctions, 1) != jm_status_success) {
         throw std::runtime_error(std::string("failed to load fmu dll! Error: ") + fmi1_import_get_last_error(handle_));

--- a/src/proxyfmu/fmi/fmi2/fmi2_slave.cpp
+++ b/src/proxyfmu/fmi/fmi2/fmi2_slave.cpp
@@ -30,12 +30,12 @@ fmi2_slave::fmi2_slave(
     , tmpDir_(std::move(tmpDir))
     , handle_(fmi2_import_parse_xml(ctx->ctx_, tmpDir->path().string().c_str(), nullptr))
 {
-
     fmi2_callback_functions_t callbackFunctions;
     callbackFunctions.allocateMemory = calloc;
     callbackFunctions.freeMemory = free;
     callbackFunctions.logger = &fmilogger;
     callbackFunctions.componentEnvironment = nullptr;
+    callbackFunctions.stepFinished = nullptr;
 
     if (fmi2_import_create_dllfmu(handle_, fmi2_fmu_kind_cs, &callbackFunctions) != jm_status_success) {
         throw std::runtime_error(std::string("failed to load fmu dll! Error: ") + fmi2_import_get_last_error(handle_));


### PR DESCRIPTION
I found that `stepFinished` is not initialised here and it may be initialised to a garbage number (non-zero) depending on the compiler/platform etc. It seems some of the fmus may check if the function is initialised (if it is zero or not) and calling it resulted in crashing proxyfmu.

This patch just adds `nullptr` to stepFinished to avoid this issue.