### PR TITLE
Fix possible deadlock on linux

### DIFF
--- a/src/proxyfmu/process_helper.hpp
+++ b/src/proxyfmu/process_helper.hpp
@@ -83,17 +83,17 @@ void start_process(
     }
 
     c.wait();
+    int status = c.exit_code();
 
-    auto status = c.exit_code();
-    std::cout << "[proxyfmu] External proxy process for instance '" << instanceName << "' returned with status " << std::to_string(status) << std::endl;
+    if (status == 0 && bound) {
+        return;
+    } else {
+        std::cerr << "[proxyfmu] External proxy process for instance '"
+                  << instanceName << "' returned with status "
+                  << std::to_string(status) << ". Unable to bind.." << std::endl;
+        std::lock_guard<std::mutex> lck(mtx);
+        port = -999;
 
-    // exit code -999 has special meaning: not able to bind to a port
-    if (!bound && status == -999) {
-        {
-            std::lock_guard<std::mutex> lck(mtx);
-            std::cerr << "[proxyfmu] Unable to bind to external proxy process!" << std::endl;
-            port = -999;
-        }
         cv.notify_one();
     }
 }

--- a/tool/proxyfmu.cpp
+++ b/tool/proxyfmu.cpp
@@ -89,7 +89,13 @@ int run_application(const std::string& fmu, const std::string& instanceName)
         }
     }
 
-    return final_port != -1 ? 0 : -999;
+    if (final_port != -1) {
+        return 0;
+    } else {
+        std::cerr << "[proxyfmu] Unable to bind after max number of retries.." << std::endl;
+        return 1;
+    }
+
 }
 
 int printHelp(boost::program_options::options_description& desc)


### PR DESCRIPTION
If a socket bind fails, a deadlock occours on linux as system codes cannot be negative.