### PR TITLE
Rollback thrift to 0.13.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ if (PROXYFMU_BUILD_TESTS)
     FetchContent_MakeAvailable(Catch2)
 endif ()
 
-find_package(Boost 1.71 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
+find_package(Boost 1.81 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
 find_package(CLI11 REQUIRED)
 find_package(THRIFT REQUIRED)
 find_package(FMILIB REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ message("Current ${PROJECT_NAME} version: ${CMAKE_PROJECT_VERSION}\n")
 # Build settings
 # ==============================================================================
 
-set(BUILD_SHARED_LIBS OFF)
+option(BUILD_SHARED_LIBS "Build shared libraries instead of static libraries" ON)
 option(PROXYFMU_BUILD_TESTS "Build tests" OFF)
 option(PROXYFMU_BUILD_EXAMPLES "Build examples" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ if (PROXYFMU_BUILD_TESTS)
     FetchContent_MakeAvailable(Catch2)
 endif ()
 
-find_package(Boost 1.81 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
+find_package(Boost 1.71 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
 find_package(CLI11 REQUIRED)
 find_package(THRIFT REQUIRED)
 find_package(FMILIB REQUIRED)

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,7 +17,7 @@ class ProxyFmuConan(ConanFile):
     requires = (
         "cli11/2.3.1",
         "fmilibrary/2.3",
-        "thrift/0.17.0"
+        "thrift/0.13.0"
     )
 
     def set_version(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -16,9 +16,14 @@ class ProxyFmuConan(ConanFile):
     generators = "cmake"
     requires = (
         "cli11/2.3.1",
-        "boost/1.81.0",
         "fmilibrary/2.3",
         "thrift/0.13.0"
+    )
+    options = {
+        "shared": [True, False]
+    }
+    default_options = (
+        "shared=True"
     )
 
     def set_version(self):
@@ -26,6 +31,7 @@ class ProxyFmuConan(ConanFile):
 
     def configure_cmake(self):
         cmake = CMake(self)
+        cmake.definitions["BUILD_SHARED_LIBS"] = self.options.shared
         cmake.configure()
         return cmake
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -16,6 +16,7 @@ class ProxyFmuConan(ConanFile):
     generators = "cmake"
     requires = (
         "cli11/2.3.1",
+        "boost/1.81.0",
         "fmilibrary/2.3",
         "thrift/0.13.0"
     )


### PR DESCRIPTION
The latest thrift (0.17.0) is still causing a problem #36.
Rolling it back to 0.13.0 until we find a proper fix