### PR TITLE
Thrift upgrade to 0.21.0

### DIFF
--- a/.github/workflows/upload-conan-pkgs.yml
+++ b/.github/workflows/upload-conan-pkgs.yml
@@ -42,9 +42,10 @@ jobs:
           #!/bin/bash -v
           set -eu
           cd /mnt/source
-          conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
-          pip install conan --user --upgrade
+          rm -rf ~/.conan2
+          pip install --user --upgrade conan~=2.22
           conan profile detect --force
+          conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
           REFNAME="${GITHUB_REF#refs/*/}"
           VERSION="v$(<version.txt)"
           if [[ $GITHUB_REF == refs/tags/* ]] && [[ $REFNAME == $VERSION ]]; then CHANNEL="stable"

--- a/.github/workflows/upload-conan-pkgs.yml
+++ b/.github/workflows/upload-conan-pkgs.yml
@@ -43,6 +43,7 @@ jobs:
           set -eu
           cd /mnt/source
           conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
+          pip install conan --user --upgrade
           conan profile detect --force
           REFNAME="${GITHUB_REF#refs/*/}"
           VERSION="v$(<version.txt)"

--- a/conanfile.py
+++ b/conanfile.py
@@ -36,7 +36,7 @@ class ProxyFmuConan(ConanFile):
         self.requires("cli11/[~2.3]")
         self.requires("fmilibrary/[~2.3]")
         self.requires("boost/[~1.85]") # Required by Thrift
-        self.requires("thrift/[~0.20]", transitive_headers=True)
+        self.requires("thrift/[~0.21]", transitive_headers=True)
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/conanfile.py
+++ b/conanfile.py
@@ -32,7 +32,7 @@ class ProxyFmuConan(ConanFile):
 
     def requirements(self):
         self.tool_requires("cmake/[>=3.15]")
-        self.tool_requires("thrift/[~0.20]")
+        self.tool_requires("thrift/[~0.21]")
         self.requires("cli11/[~2.3]")
         self.requires("fmilibrary/[~2.3]")
         self.requires("boost/[~1.85]") # Required by Thrift


### PR DESCRIPTION
Upgraded thrift to 0.21.0 that resolves an issue on resetting consumed message size.~~
See details here: https://github.com/apache/thrift/pull/3228

Update -- need to wait for 0.23.0 release

