### PR TITLE
Override cli11 to ~2.6 to support cmake v4

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -33,7 +33,7 @@ class ProxyFmuConan(ConanFile):
     def requirements(self):
         self.tool_requires("cmake/[>=4.0]")
         self.tool_requires("thrift/[~0.20]")
-        self.requires("cli11/[~2.3]")
+        self.requires("cli11/[~2.6]")
         self.requires("fmilibrary/[~2.3]")
         self.requires("boost/[~1.85]") # Required by Thrift
         self.requires("thrift/[~0.20]", transitive_headers=True)


### PR DESCRIPTION
Upgraded cli11 because older cli11 does not support cmakev4.

Also we need to update fmilibrary to use newer dependencies.